### PR TITLE
Implemented Entity view for the CRM

### DIFF
--- a/backend/handlers/picklist.go
+++ b/backend/handlers/picklist.go
@@ -38,16 +38,17 @@ type PicklistResponse struct {
 func (h *PicklistHandler) GetPicklistByEntity(c *gin.Context) {
 	entityType := c.Param("entity")
 
-	// Get user from context
-	user, exists := c.Get("user")
+	// Get user ID from context
+	userID, exists := c.Get("user_id")
 	if !exists {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "User not found in context"})
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
 		return
 	}
 
-	userObj, ok := user.(models.User)
-	if !ok {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid user in context"})
+	// Get user from database
+	var userObj models.User
+	if err := h.db.Select("tenant_id").First(&userObj, "id = ?", userID).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "User not found"})
 		return
 	}
 
@@ -160,16 +161,17 @@ func (h *PicklistHandler) SearchPicklist(c *gin.Context) {
 		return
 	}
 
-	// Get user from context
-	user, exists := c.Get("user")
+	// Get user ID from context
+	userID, exists := c.Get("user_id")
 	if !exists {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "User not found in context"})
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
 		return
 	}
 
-	userObj, ok := user.(models.User)
-	if !ok {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid user in context"})
+	// Get user from database
+	var userObj models.User
+	if err := h.db.Select("tenant_id").First(&userObj, "id = ?", userID).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "User not found"})
 		return
 	}
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -3,12 +3,15 @@
 import { useState } from 'react'
 import { TopToolbar } from '@/components/TopToolbar'
 import { LeftSidebar } from '@/components/LeftSidebar'
-import { Dashboard } from '@/components/Dashboard'
 import { Login } from '@/components/Login'
 import { useAuth } from '@/contexts/AuthContext'
+import { MainLayout } from '@/components/MainLayout'
+
+import { EntityType } from '@/components/EntityPage'
 
 export default function Home() {
   const [sidebarOpen, setSidebarOpen] = useState(true)
+  const [activeEntity, setActiveEntity] = useState<EntityType | null>(null)
   const { isAuthenticated, isLoading } = useAuth()
 
   // Show loading state
@@ -22,7 +25,7 @@ export default function Home() {
       </div>
     )
   }
-
+  console.log("isAuthenticated", isAuthenticated, isLoading)
   // Show login if not authenticated
   if (!isAuthenticated) {
     return <Login />
@@ -36,11 +39,18 @@ export default function Home() {
       
       <div className="flex flex-1 overflow-hidden">
         {/* Left Sidebar */}
-        <LeftSidebar isOpen={sidebarOpen} />
+        <LeftSidebar 
+          isOpen={sidebarOpen} 
+          activeEntity={activeEntity}
+          onEntitySelect={(entityType) => setActiveEntity(entityType)}
+        />
         
         {/* Main Content */}
         <main className="flex-1 overflow-auto">
-          <Dashboard />
+          <MainLayout 
+            initialEntity={activeEntity ? { type: activeEntity } : undefined}
+            onEntityChange={(entity) => setActiveEntity(entity?.type || null)}
+          />
         </main>
       </div>
     </div>

--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -2,8 +2,11 @@
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { AuthProvider } from '@/contexts/AuthContext'
+
+var acount = 1
+
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -16,6 +19,12 @@ export function Providers({ children }: { children: React.ReactNode }) {
         },
       })
   )
+  const [count, setCount] = useState(1);
+  console.log("Providers", count)
+
+  useEffect(() => {
+    setCount(count + 1)
+  }, [])
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/frontend/components/Dashboard.tsx
+++ b/frontend/components/Dashboard.tsx
@@ -5,8 +5,13 @@ import { TrendingUp, Users, Target, DollarSign, Activity, Building2, Phone, Mail
 import { apiClient, DashboardStats } from '@/services/api'
 import { AddCompanyModal } from './AddCompanyModal'
 import { AddContactModal } from './AddContactModal'
+import { EntityType } from './EntityPage'
 
-export function Dashboard() {
+interface DashboardProps {
+  onEntitySelect?: (entityType: EntityType) => void
+}
+
+export function Dashboard({ onEntitySelect }: DashboardProps) {
   const [stats, setStats] = useState<DashboardStats | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)

--- a/frontend/components/EntityPage.tsx
+++ b/frontend/components/EntityPage.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { useState } from 'react'
+import { EntityView } from './EntityView'
+
+// Export the EntityType so it can be reused elsewhere
+export type EntityType = 'companies' | 'contacts' | 'leads' | 'deals' | 
+                  'industries' | 'companysizes' | 'leadstatuses' | 'leadtemperatures'
+
+interface EntityPageProps {
+  params: {
+    entityType: EntityType
+  }
+}
+
+// Mapping of entity types to display names
+const entityDisplayNames: Record<EntityType, string> = {
+  companies: 'Companies',
+  contacts: 'Contacts',
+  leads: 'Leads',
+  deals: 'Deals',
+  industries: 'Industries',
+  companysizes: 'Company Sizes',
+  leadstatuses: 'Lead Statuses',
+  leadtemperatures: 'Lead Temperatures'
+}
+
+export function EntityPage({ params }: EntityPageProps) {
+  const { entityType } = params
+  const [selectedEntity, setSelectedEntity] = useState<Record<string, any> | null>(null)
+  
+  const displayName = entityDisplayNames[entityType as EntityType] || 
+                      entityType.charAt(0).toUpperCase() + entityType.slice(1)
+  
+  // Handle entity selection for viewing details
+  const handleEntityClick = (entity: Record<string, any>) => {
+    setSelectedEntity(entity)
+  }
+  
+  // Handle back button click to return to list
+  const handleBackClick = () => {
+    setSelectedEntity(null)
+  }
+
+  return (
+    <div className="h-screen flex flex-col">
+      <div className="flex-1 overflow-hidden">
+        {selectedEntity ? (
+          // Show entity details when selected
+          <div className="h-full">
+            {/* This would be a detail view component, not implemented yet */}
+            <div className="bg-white h-full p-6">
+              <button 
+                onClick={handleBackClick}
+                className="mb-4 px-3 py-1 text-sm flex items-center text-blue-600 hover:text-blue-800"
+              >
+                ← Back to list
+              </button>
+              <h2 className="text-2xl font-semibold mb-4">
+                {selectedEntity.name || selectedEntity.firstName + ' ' + selectedEntity.lastName || `${displayName} Details`}
+              </h2>
+              
+              <pre className="bg-gray-100 p-4 rounded text-sm overflow-auto max-h-96">
+                {JSON.stringify(selectedEntity, null, 2)}
+              </pre>
+            </div>
+          </div>
+        ) : (
+          // Show entity list
+          <EntityView 
+            entityType={entityType} 
+            title={displayName}
+            onEntityClick={handleEntityClick}
+          />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/EntityView.tsx
+++ b/frontend/components/EntityView.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import { useState, useRef, useEffect } from 'react'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { EntityList } from './EntityList'
+import { useEntityList } from '../hooks/useEntityList'
+import { ChevronLeft, Settings } from 'lucide-react'
+
+interface EntityViewProps {
+  entityType: string
+  title?: string
+  onBack?: () => void
+  onEntityClick?: (entity: Record<string, any>) => void
+}
+
+export function EntityView({ entityType, title, onBack, onEntityClick }: EntityViewProps) {
+  const [activeView, setActiveView] = useState<string | null>(null)
+  const listRef = useRef<HTMLDivElement>(null)
+  
+  // Get entity data and views
+  const {
+    views,
+    currentView,
+    changeView,
+    hasMore,
+    loading,
+    loadMore
+  } = useEntityList({
+    entityType
+  })
+
+  // Set active view when views load
+  useEffect(() => {
+    if (views.length > 0 && !activeView) {
+      setActiveView(views[0].name)
+    }
+  }, [views, activeView])
+
+  // Handle infinite scroll
+  useEffect(() => {
+    const handleScroll = () => {
+      if (!listRef.current || loading || !hasMore) return
+
+      const { scrollTop, clientHeight, scrollHeight } = listRef.current
+      
+      // Load more when user scrolls to bottom (with a buffer of 200px)
+      if (scrollTop + clientHeight >= scrollHeight - 200) {
+        loadMore()
+      }
+    }
+
+    const currentRef = listRef.current
+    if (currentRef) {
+      currentRef.addEventListener('scroll', handleScroll)
+    }
+    
+    return () => {
+      if (currentRef) {
+        currentRef.removeEventListener('scroll', handleScroll)
+      }
+    }
+  }, [loading, hasMore, loadMore])
+
+  // Display name for the entity type
+  const displayName = title || `${entityType.charAt(0).toUpperCase() + entityType.slice(1)}`
+
+  return (
+    <div className="h-full flex flex-col">
+      {/* Header */}
+      <div className="bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between">
+        <div className="flex items-center space-x-4">
+          {onBack && (
+            <button 
+              onClick={onBack} 
+              className="p-2 rounded-full hover:bg-gray-100"
+            >
+              <ChevronLeft className="w-5 h-5 text-gray-500" />
+              <span className="sr-only">Back to Dashboard</span>
+            </button>
+          )}
+          <h1 className="text-2xl font-semibold text-gray-900">{displayName}</h1>
+        </div>
+        
+        <div className="flex items-center space-x-2">
+          <button className="px-4 py-2 border border-gray-300 rounded-md text-sm text-gray-700 hover:bg-gray-50 flex items-center space-x-1">
+            <Settings className="w-4 h-4" />
+            <span>Settings</span>
+          </button>
+        </div>
+      </div>
+
+      {/* Views Tabs */}
+      {views.length > 0 && (
+        <div className="border-b border-gray-200 bg-white">
+          <Tabs 
+            value={activeView || views[0].name} 
+            onValueChange={tab => {
+              setActiveView(tab)
+              changeView(tab)
+            }}
+            className="px-6"
+          >
+            <TabsList>
+              {views.map(view => (
+                <TabsTrigger key={view.name} value={view.name}>
+                  {view.displayName}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
+        </div>
+      )}
+
+      {/* Content Area with Infinite Scroll */}
+      <div 
+        ref={listRef}
+        className="flex-1 overflow-y-auto"
+      >
+        {activeView && (
+          <div className="p-6">
+            <EntityList 
+              entityType={entityType}
+              title={undefined} // No title needed as we have the header
+              onEntityClick={onEntityClick}
+            />
+            
+            {/* Loading indicator for infinite scroll */}
+            {loading && hasMore && (
+              <div className="flex justify-center p-4">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/LeftSidebar.tsx
+++ b/frontend/components/LeftSidebar.tsx
@@ -18,11 +18,37 @@ import {
   Tag
 } from 'lucide-react'
 
+import { EntityType } from './EntityPage'
+
 interface LeftSidebarProps {
   isOpen: boolean
+  activeEntity?: EntityType | null
+  onEntitySelect?: (entityType: EntityType) => void
 }
 
-export function LeftSidebar({ isOpen }: LeftSidebarProps) {
+export function LeftSidebar({ isOpen, activeEntity = null, onEntitySelect }: LeftSidebarProps) {
+  // Map URL paths to entity types
+  const entityTypeMap: Record<string, EntityType> = {
+    '/companies': 'companies',
+    '/contacts': 'contacts',
+    '/leads': 'leads',
+    '/deals': 'deals',
+    '/industries': 'industries',
+    '/sizes': 'companysizes',
+    '/lead-statuses': 'leadstatuses',
+    '/temperatures': 'leadtemperatures'
+  }
+
+  // Handle entity item click
+  const handleEntityClick = (e: React.MouseEvent, href: string) => {
+    e.preventDefault()
+    
+    const entityType = entityTypeMap[href]
+    if (entityType && onEntitySelect) {
+      onEntitySelect(entityType)
+    }
+  }
+
   const navigationItems = [
     {
       title: 'Core CRM',
@@ -144,7 +170,12 @@ export function LeftSidebar({ isOpen }: LeftSidebarProps) {
                   <a
                     key={itemIndex}
                     href={item.href}
-                    className="flex items-start justify-between px-3 py-2 rounded-lg hover:bg-gray-100 transition-colors text-sm text-gray-700 group"
+                    onClick={(e) => entityTypeMap[item.href] && handleEntityClick(e, item.href)}
+                    className={`flex items-start justify-between px-3 py-2 rounded-lg hover:bg-gray-100 transition-colors text-sm group
+                      ${activeEntity === entityTypeMap[item.href] 
+                        ? 'bg-blue-50 text-blue-700 border-l-4 border-blue-500' 
+                        : 'text-gray-700'}
+                    `}
                   >
                     <div className="flex-1">
                       <span className="block">{item.name}</span>

--- a/frontend/components/Login.tsx
+++ b/frontend/components/Login.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
 import { Building2, Eye, EyeOff } from 'lucide-react'
 
@@ -88,7 +88,7 @@ export function Login() {
                       value={firstName}
                       onChange={(e) => setFirstName(e.target.value)}
                       className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                      placeholder="John"
+                      placeholder="Jon"
                     />
                   </div>
                   <div>
@@ -123,7 +123,7 @@ export function Login() {
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                placeholder="john@example.com"
+                placeholder="jon@example.com"
               />
             </div>
 

--- a/frontend/components/MainLayout.tsx
+++ b/frontend/components/MainLayout.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { Dashboard } from '@/components/Dashboard'
+import { EntityView } from '@/components/EntityView'
+import { EntityType } from '@/components/EntityPage'
+
+interface MainLayoutProps {
+  initialEntity?: {
+    type: EntityType
+    id?: string
+  }
+  onEntityChange?: (entity: {type: EntityType, id?: string} | null) => void
+}
+
+export function MainLayout({ initialEntity, onEntityChange }: MainLayoutProps) {
+  const [activeEntity, setActiveEntity] = useState<{type: EntityType, id?: string} | null>(
+    initialEntity || null
+  )
+
+  // Update internal state when props change
+  useEffect(() => {
+    setActiveEntity(initialEntity || null)
+  }, [initialEntity])
+
+  const handleEntitySelect = (entityType: EntityType) => {
+    const newEntity = { type: entityType }
+    setActiveEntity(newEntity)
+    if (onEntityChange) {
+      onEntityChange(newEntity)
+    }
+  }
+
+  const handleEntityBack = () => {
+    setActiveEntity(null)
+    if (onEntityChange) {
+      onEntityChange(null)
+    }
+  }
+
+  return (
+    <>
+      {activeEntity ? (
+        // Show entity view when an entity is selected
+        <EntityView 
+          entityType={activeEntity.type}
+          onBack={handleEntityBack}
+        />
+      ) : (
+        // Show dashboard when no entity is selected
+        <Dashboard onEntitySelect={handleEntitySelect} />
+      )}
+    </>
+  )
+}

--- a/frontend/components/PicklistFilter.tsx
+++ b/frontend/components/PicklistFilter.tsx
@@ -1,0 +1,199 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { usePicklist } from '@/hooks/usePicklist'
+import { ChevronDown, X, Check, Search } from 'lucide-react'
+
+interface PicklistFilterProps {
+  entityType: string // The picklist entity type (e.g., 'industries', 'companysizes')
+  value: string | null // Current selected value ID
+  onChange: (value: string | null) => void
+  placeholder?: string
+  label?: string
+  className?: string
+  operator?: string
+  onOperatorChange?: (operator: string) => void
+  showOperator?: boolean
+  disabled?: boolean
+}
+
+export function PicklistFilter({
+  entityType,
+  value,
+  onChange,
+  placeholder = 'Select...',
+  label,
+  className = '',
+  operator = 'eq',
+  onOperatorChange,
+  showOperator = false,
+  disabled = false
+}: PicklistFilterProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
+  
+  // Get picklist items using the usePicklist hook
+  const {
+    items,
+    loading,
+    error,
+    search,
+    refresh
+  } = usePicklist({
+    entityType: entityType as any, // Cast to the expected type
+    searchable: true,
+    preload: true
+  })
+
+  // Find the selected item's name for display
+  const selectedItem = items.find(item => item.id === value)
+  
+  // Close dropdown if clicked outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as HTMLElement
+      if (isOpen && !target.closest(`[data-picklist="${entityType}"]`)) {
+        setIsOpen(false)
+      }
+    }
+    
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [isOpen, entityType])
+
+  // Handle search input
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const query = e.target.value
+    setSearchQuery(query)
+    
+    // Debounce search
+    const timeoutId = setTimeout(() => {
+      search(query)
+    }, 300)
+    
+    return () => clearTimeout(timeoutId)
+  }
+
+  // Handle item selection
+  const handleSelect = (itemId: string | null) => {
+    onChange(itemId)
+    setIsOpen(false)
+    setSearchQuery('')
+  }
+
+  const operators = [
+    { value: 'eq', label: 'Equals' },
+    { value: 'neq', label: 'Not Equals' }
+  ]
+
+  return (
+    <div className={`relative ${className}`} data-picklist={entityType}>
+      {label && (
+        <label className="block text-xs font-medium text-gray-500 mb-1">
+          {label}
+        </label>
+      )}
+      
+      <div className="flex space-x-2">
+        {/* Operator selector */}
+        {showOperator && (
+          <select
+            value={operator}
+            onChange={(e) => onOperatorChange?.(e.target.value)}
+            disabled={disabled}
+            className="flex-shrink-0 w-24 border border-gray-300 rounded px-1 py-1 text-xs"
+          >
+            {operators.map(op => (
+              <option key={op.value} value={op.value}>{op.label}</option>
+            ))}
+          </select>
+        )}
+        
+        {/* Picklist selector */}
+        <div className="relative w-full">
+          <button
+            type="button"
+            onClick={() => !disabled && setIsOpen(!isOpen)}
+            disabled={disabled}
+            className={`w-full flex items-center justify-between border rounded px-2 py-1 text-xs ${
+              disabled 
+                ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
+                : 'bg-white hover:bg-gray-50 text-gray-900'
+            } ${
+              isOpen ? 'border-blue-500 ring-1 ring-blue-500' : 'border-gray-300'
+            }`}
+          >
+            <span className={`${!selectedItem && 'text-gray-500'}`}>
+              {selectedItem ? selectedItem.name : placeholder}
+            </span>
+            <div className="flex items-center">
+              {value && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    handleSelect(null)
+                  }}
+                  className="mr-1 text-gray-400 hover:text-gray-600"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              )}
+              <ChevronDown className="h-3 w-3 text-gray-400" />
+            </div>
+          </button>
+          
+          {isOpen && (
+            <div className="absolute z-10 w-full mt-1 bg-white border border-gray-300 rounded shadow-lg">
+              {/* Search input */}
+              <div className="p-2 border-b border-gray-200">
+                <div className="relative">
+                  <input
+                    type="text"
+                    value={searchQuery}
+                    onChange={handleSearchChange}
+                    placeholder="Search..."
+                    className="w-full border border-gray-300 rounded pl-8 pr-2 py-1 text-xs"
+                    autoFocus
+                  />
+                  <Search className="h-3 w-3 text-gray-400 absolute left-2 top-1.5" />
+                </div>
+              </div>
+              
+              {/* List of items */}
+              <div className="max-h-48 overflow-y-auto py-1">
+                {loading ? (
+                  <div className="text-center p-2 text-xs text-gray-500">
+                    Loading...
+                  </div>
+                ) : error ? (
+                  <div className="text-center p-2 text-xs text-red-500">
+                    {error}
+                  </div>
+                ) : items.length === 0 ? (
+                  <div className="text-center p-2 text-xs text-gray-500">
+                    No items found
+                  </div>
+                ) : (
+                  items.map((item) => (
+                    <button
+                      key={item.id}
+                      type="button"
+                      onClick={() => handleSelect(item.id)}
+                      className="w-full text-left px-3 py-2 text-xs hover:bg-gray-100 flex items-center justify-between"
+                    >
+                      <span>{item.name}</span>
+                      {value === item.id && (
+                        <Check className="h-3 w-3 text-blue-500" />
+                      )}
+                    </button>
+                  ))
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/ui/tabs.tsx
+++ b/frontend/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center bg-transparent p-1 text-gray-500",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-2 text-sm font-medium ring-offset-white transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:border-b-2 data-[state=active]:border-blue-600 data-[state=active]:text-blue-600 data-[state=active]:shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/frontend/contexts/AuthContext.tsx
+++ b/frontend/contexts/AuthContext.tsx
@@ -30,6 +30,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const [user, setUser] = useState<User | null>(null)
   const [isLoading, setIsLoading] = useState(true)
 
+
   // Function to validate token and get user info
   const validateToken = async (token: string): Promise<User | null> => {
     try {
@@ -38,10 +39,13 @@ export function AuthProvider({ children }: AuthProviderProps) {
       if (response.data) {
         return response.data
       } else {
+        console.log("Token validation failed: User data not returned")
+        apiClient.clearToken() // Clear the token if the response doesn't include user data
         return null
       }
     } catch (error) {
       console.error('Token validation failed:', error)
+      apiClient.clearToken() // Clear the token on any error
       return null
     }
   }
@@ -50,24 +54,69 @@ export function AuthProvider({ children }: AuthProviderProps) {
     const initializeAuth = async () => {
       try {
         const token = localStorage.getItem('auth_token')
+        // Try to get cached user data first
+        const cachedUserData = localStorage.getItem('auth_user')
+        
         if (token) {
           // Set the token in the API client
           apiClient.setToken(token)
           
-          // Validate the token by getting current user info
-          const userData = await validateToken(token)
-          if (userData) {
-            setUser(userData)
+          // First try to use cached user data
+          if (cachedUserData) {
+            try {
+              const parsedUser = JSON.parse(cachedUserData)
+              setUser(parsedUser)
+              
+              // Validate the token in the background
+              validateToken(token).then(userData => {
+                if (userData) {
+                  // Update with fresh data if available
+                  setUser(userData)
+                  localStorage.setItem('auth_user', JSON.stringify(userData))
+                } else {
+                  // Token is invalid, remove everything
+                  setUser(null)
+                  console.log("Token is invalid, removing it (3)")
+                  localStorage.removeItem('auth_token')
+                  localStorage.removeItem('auth_user')
+                  apiClient.clearToken()
+                }
+              })
+            } catch (e) {
+              console.error('Error parsing cached user data:', e)
+              // Fallback to token validation
+              const userData = await validateToken(token)
+              if (userData) {
+                setUser(userData)
+                localStorage.setItem('auth_user', JSON.stringify(userData))
+              } else {
+                // Token is invalid, remove it
+                console.log("Token is invalid, removing it (1)")
+                localStorage.removeItem('auth_token')
+                localStorage.removeItem('auth_user')
+                apiClient.clearToken()
+              }
+            }
           } else {
-            // Token is invalid, remove it
-            localStorage.removeItem('auth_token')
-            apiClient.clearToken()
+            // No cached user data, validate token
+            const userData = await validateToken(token)
+            if (userData) {
+              setUser(userData)
+              localStorage.setItem('auth_user', JSON.stringify(userData))
+            } else {
+              // Token is invalid, remove it
+              console.log("Token is invalid, removing it (2)")
+              localStorage.removeItem('auth_token')
+              apiClient.clearToken()
+            }
           }
         }
       } catch (error) {
         console.error('Auth initialization failed:', error)
-        // Clear invalid token
+        // Clear invalid token and user data
+        console.log("Auth initialization failed, removing token and user data")
         localStorage.removeItem('auth_token')
+        localStorage.removeItem('auth_user')
         apiClient.clearToken()
       } finally {
         setIsLoading(false)
@@ -75,7 +124,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     }
 
     initializeAuth()
-  }, [])
+ }, [])
 
   const login = async (email: string, password: string) => {
     try {
@@ -83,7 +132,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
       const response = await apiClient.login(email, password)
       
       if (response.data) {
+        // Save the user data in state
         setUser(response.data.user)
+        // Also save user data in localStorage for persistence
+        localStorage.setItem('auth_user', JSON.stringify(response.data.user))
         return { success: true }
       } else {
         return { success: false, error: response.error || 'Login failed' }
@@ -101,7 +153,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
       const response = await apiClient.register(email, password, firstName, lastName)
       
       if (response.data) {
+        // Save the user data in state
         setUser(response.data.user)
+        // Also save user data in localStorage for persistence
+        localStorage.setItem('auth_user', JSON.stringify(response.data.user))
         return { success: true }
       } else {
         return { success: false, error: response.error || 'Registration failed' }
@@ -116,6 +171,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const logout = () => {
     setUser(null)
     apiClient.clearToken()
+    // Also remove user data from localStorage
+    localStorage.removeItem('auth_user')
   }
 
   const value: AuthContextType = {

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+ 
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "finhub-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-tabs": "^1.0.4",
         "@tanstack/react-query": "^5.0.0",
         "@tanstack/react-query-devtools": "^5.0.0",
         "axios": "^1.6.0",
@@ -451,6 +452,279 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -549,13 +823,13 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -565,7 +839,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -1615,7 +1889,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,9 @@
     "tailwind-merge": "^2.0.0",
     "lucide-react": "^0.294.0",
     "class-variance-authority": "^0.7.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "@radix-ui/react-tabs": "^1.0.4"
+
   },
   "devDependencies": {
     "typescript": "^5",

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -220,9 +220,14 @@ class ApiClient {
       })
 
       if (response.status === 401) {
-        // Token expired or invalid
-        this.clearToken()
-        return { error: 'Authentication required' }
+        // Token expired or invalid or we dont have permission 
+        // in any case the token should not be cleared unless we have
+        // been explicitly asked to do so or we test it against the
+        // backend to see if it is valid and the backend says it is invalid
+        // simply receiving a 401 here is *not* sufficient to clear the token
+        
+        //this.clearToken()
+        return { error: 'Not Authenticated' }
       }
 
       if (!response.ok) {


### PR DESCRIPTION
ok on the dashboard page, when we click an entity under the core CRM section on the left hand side, the interface should show views of this entity.  In particular it shoudl show a tab box of views of the entity, the first view being a filterable paginated list of entiries for this entity in the database.  It would be cool if the pagination could be implemented as an infinite scroll.   We shoudl be able to filter on the value in any column, including for controlled values bringing up picklist selectors for those values. 



ok I like the entity viewer, however what I intended is for the toolbars at the top of the screen and the left of the page in the dashboard view to remain when the entity view comes in.   All that should change is maybe that the entity in the list in the left hand toolbar might be highlighted in some way, and the dashboard components should be replaced with the entity viewer.